### PR TITLE
Make plone.app.blob and ATCT optional

### DIFF
--- a/experimental/gracefulblobmissing/configure.zcml
+++ b/experimental/gracefulblobmissing/configure.zcml
@@ -9,6 +9,7 @@
     <include package="collective.monkeypatcher" />
     <include package="collective.monkeypatcher" file="meta.zcml" />
 
+    <configure zcml:condition="installed plone.app.blob">
     <monkey:patch
         description="Fix get_size method for blob fields"
         class="plone.app.blob.field.BlobWrapper"
@@ -27,18 +28,21 @@
         />
 
     <monkey:patch
-        description="Fix get_size method for blob fields"
-        class="Products.ATContentTypes.content.base.ATCTMixin"
-        original="get_size"
-        replacement=".patches.patched_class_get_size"
-        docstringWarning="true"
-        />
-
-    <monkey:patch
         description="Fix getScale method for blob mixins"
         class="plone.app.blob.mixins.ImageFieldMixin"
         original="getScale"
         replacement=".patches.patched_getScale"
+        docstringWarning="true"
+        />
+
+    </configure>
+
+    <configure zcml:condition="installed Products.ATContentTypes">
+    <monkey:patch
+        description="Fix get_size method for blob fields"
+        class="Products.ATContentTypes.content.base.ATCTMixin"
+        original="get_size"
+        replacement=".patches.patched_class_get_size"
         docstringWarning="true"
         />
 
@@ -49,6 +53,7 @@
         replacement=".patches.patched_SearchableText"
         docstringWarning="true"
         />
+    </configure>
 
     <monkey:patch
         description="Create the blob folder path and create (touch) an empty file for each blob file if it's missing."

--- a/experimental/gracefulblobmissing/patches.py
+++ b/experimental/gracefulblobmissing/patches.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from plone.app.blob.utils import openBlob
-from plone.app.imaging.interfaces import IImageScaleHandler
+try:
+    from plone.app.blob.utils import openBlob
+    from plone.app.imaging.interfaces import IImageScaleHandler
+except ImportError:
+    pass
 from Products.CMFCore.utils import getToolByName
 from sh import mkdir
 from ZEO import ClientStorage

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(name='experimental.gracefulblobmissing',
       install_requires=[
           'setuptools',
           'collective.monkeypatcher>=1.0',
-          'plone.app.blob',
           'sh'
       ],
       entry_points="""


### PR DESCRIPTION
Remove the hard dependency on `plone.app.blob` and only monkey patch `plone.app.blob` and `Products.ATContentTypes` if they are installed.

This makes this package Plone 5.1+ friendly :smile: 