### PR TITLE
Remove Archetypes compatibility code.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-1.1 (unreleased)
+2.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Remove Archetypes compatibility code.
+  [thet]
 
 
 1.0 (2022-03-11)

--- a/experimental/gracefulblobmissing/configure.zcml
+++ b/experimental/gracefulblobmissing/configure.zcml
@@ -1,59 +1,10 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:five="http://namespaces.zope.org/five"
-    xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:monkey="http://namespaces.plone.org/monkey"
-    xmlns:zcml="http://namespaces.zope.org/zcml"
-    i18n_domain="experimental.gracefulblobmissing">
+    xmlns:zcml="http://namespaces.zope.org/zcml">
 
     <include package="collective.monkeypatcher" />
     <include package="collective.monkeypatcher" file="meta.zcml" />
-
-    <configure zcml:condition="installed plone.app.blob">
-    <monkey:patch
-        description="Fix get_size method for blob fields"
-        class="plone.app.blob.field.BlobWrapper"
-        original="get_size"
-        replacement=".patches.patched_field_get_size"
-        docstringWarning="true"
-        />
-
-    <monkey:patch
-        description="Fix index_html method for blob fields"
-        class="plone.app.blob.field.BlobField"
-        original="index_html"
-        replacement=".patches.patched_field_index_html"
-        docstringWarning="true"
-        preserveOriginal="true"
-        />
-
-    <monkey:patch
-        description="Fix getScale method for blob mixins"
-        class="plone.app.blob.mixins.ImageFieldMixin"
-        original="getScale"
-        replacement=".patches.patched_getScale"
-        docstringWarning="true"
-        />
-
-    </configure>
-
-    <configure zcml:condition="installed Products.ATContentTypes">
-    <monkey:patch
-        description="Fix get_size method for blob fields"
-        class="Products.ATContentTypes.content.base.ATCTMixin"
-        original="get_size"
-        replacement=".patches.patched_class_get_size"
-        docstringWarning="true"
-        />
-
-    <monkey:patch
-        description="Fix SearchableText for Archetypes when blob is missing"
-        class="Products.Archetypes.BaseObject.BaseObject"
-        original="SearchableText"
-        replacement=".patches.patched_SearchableText"
-        docstringWarning="true"
-        />
-    </configure>
 
     <monkey:patch
         description="Create the blob folder path and create (touch) an empty file for each blob file if it's missing."

--- a/experimental/gracefulblobmissing/patches.py
+++ b/experimental/gracefulblobmissing/patches.py
@@ -1,16 +1,8 @@
 # -*- coding: utf-8 -*-
-
-try:
-    from plone.app.blob.utils import openBlob
-    from plone.app.imaging.interfaces import IImageScaleHandler
-except ImportError:
-    pass
 from pkg_resources import resource_filename
-from Products.CMFCore.utils import getToolByName
 from shutil import copyfile
 from ZEO import ClientStorage
 from ZODB.blob import BlobFile
-from ZODB.POSException import ConflictError
 from ZODB.POSException import POSKeyError
 from ZODB.POSException import Unsupported
 
@@ -19,115 +11,6 @@ import os
 
 
 logger = logging.getLogger(__name__)
-
-
-def patched_field_get_size(self):
-    try:
-        blob = openBlob(self.blob)
-        size = os.fstat(blob.fileno()).st_size
-        blob.close()
-    except POSKeyError:
-        size = 0
-    return size
-
-
-def patched_class_get_size(self):
-    f = self.getPrimaryField()
-    if f is None:
-        return 0
-    try:
-        return f.get_size(self) or 0
-    except POSKeyError:
-        return 0
-
-
-def patched_field_index_html(
-    self,
-    instance,
-    REQUEST=None,
-    RESPONSE=None,
-    disposition='inline',
-):
-    try:
-        blob = self._old_index_html(
-            instance,
-            REQUEST=REQUEST,
-            RESPONSE=RESPONSE,
-            disposition=disposition,
-        )
-        if blob:
-            return blob
-        raise POSKeyError()
-    except POSKeyError:
-        if not RESPONSE:
-            RESPONSE = instance.REQUEST.RESPONSE
-        putils = getToolByName(instance, 'plone_utils')
-        putils.addPortalMessage('Missing BLOB file for %s' %
-                                instance.absolute_url_path(), type='warning')
-        RESPONSE.redirect(instance.absolute_url() + '/view')
-
-
-def patched_getScale(self, instance, scale=None, **kwargs):
-    if scale is None:
-        return self.getUnwrapped(instance, **kwargs)
-    handler = IImageScaleHandler(self, None)
-    if handler is not None:
-        try:
-            return handler.getScale(instance, scale)
-        except POSKeyError:
-            pass
-    return None
-
-
-def patched_SearchableText(self):
-    data = []
-    charset = self.getCharset()
-    for field in self.Schema().fields():
-        if not field.searchable:
-            continue
-        method = field.getIndexAccessor(self)
-        try:
-            datum = method(mimetype="text/plain")
-        except TypeError:
-            # Retry in case typeerror was raised because accessor doesn't
-            # handle the mimetype argument
-            try:
-                datum = method()
-            except (ConflictError, KeyboardInterrupt):
-                raise
-            except:
-                continue
-        except POSKeyError:
-            datum = ''
-        if datum:
-            vocab = field.Vocabulary(self)
-            if isinstance(datum, list) or isinstance(datum, tuple):
-                # Unmangle vocabulary: we index key AND value
-                vocab_values = map(
-                    lambda value, vocab=vocab: (
-                        vocab.getValue(value, ''),
-                        datum
-                    )
-                )
-                datum = list(datum)
-                datum.extend(vocab_values)
-                datum = ' '.join(datum)
-            elif isinstance(datum, basestring):
-                # Note: this patched function is only used in Archetypes,
-                # so the Python2-only code is fine.
-                if isinstance(datum, unicode):
-                    datum = datum.encode(charset)
-                value = vocab.getValue(datum, '')
-                if isinstance(value, unicode):
-                    value = value.encode(charset)
-                datum = "%s %s" % (datum, value, )
-
-            if isinstance(datum, unicode):
-                datum = datum.encode(charset)
-            data.append(str(datum))
-
-    data = ' '.join(data)
-    return data
 
 
 def patched_blob_init(self, name, mode, blob):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = "1.0.dev0"
+version = "2.0.dev0"
 
 setup(
     name="experimental.gracefulblobmissing",


### PR DESCRIPTION
Remove the AT compatibility code.

Not only is Archetypes deprecated but this package would break if there is some `plone.app.blob` module alias in a modern package and tries to import it which would fail.